### PR TITLE
Added cli interface, supporting multiple jobs at time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 *.json
 *driver
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -44,5 +44,21 @@ import sites
 
 ```python
 site = sites.Costco('./chromedriver', './credentials.json')
+site.launch()
 ```
 9. A browser window should open up, and the bot will attempt to buy a PS5. Upon success, the bot will exit.
+
+10. You can also use the included CLI pointing to a json file containing one of more configurations.
+```json
+{
+    "costco": {
+        "product": "N/A"
+    }
+}
+```
+```
+python3 buy_ps5.py --config /path/to/config.json
+```
+
+This will spawn a browser window for each product under each website. If you wish to only use
+the default url, leave a single entry with the value "N/A", otherswise give the url to the product page.

--- a/buy_ps5.py
+++ b/buy_ps5.py
@@ -1,0 +1,40 @@
+import sites as s
+from multiprocessing import Process
+import argparse
+import json
+
+all_sites = {
+    'costco': s.Costco,
+    'walmart': s.Walmart,
+    'bestbuy': s.Bestbuy
+}
+
+def run_site(site_name: str, product: str):
+    all_sites[site_name]('./chromedriver', './credentials.json').launch(product)
+
+def main():
+
+    parser = argparse.ArgumentParser(description='Get path to config file.')
+    parser.add_argument('--config', type=str)
+
+    args = parser.parse_args()
+
+    print(args.config)
+
+    configuration = json.load(open(args.config))
+
+    processes = []
+
+    for site, products in configuration.items():
+        for product in products.values():
+            prod = product if product != 'N/A' else None
+            p = Process(target=run_site, args=(site, prod))
+            p.start()
+            processes.append(p)
+
+    for p in processes:
+        p.join()
+
+
+if __name__ == '__main__':
+    main()

--- a/sites.py
+++ b/sites.py
@@ -20,6 +20,7 @@ class Site:
     _wait_timeout = 3
 
     def __init__(self, driver_path, credentials):
+        self._driver_path = driver_path
 
         try:
             with open(credentials, "r") as json_file:
@@ -31,7 +32,7 @@ class Site:
 
         # Pick a random UserAgent
         # Source: https://stackoverflow.com/a/49565254
-        options = Options()
+        self._options = Options()
         # Contacting the primary server seems to continually fail, so catch the exception
         # and move on
         try:
@@ -40,18 +41,23 @@ class Site:
             pass
         userAgent = ua.random
         print(userAgent)
-        options.add_argument("user-agent={}".format(userAgent))
+        self._options.add_argument("user-agent={}".format(userAgent))
+
+    def launch(self, product_url: str):
+        if product_url is not None:
+            self._product_urls.insert(0, product_url)
 
         try:
-            self._driver = Chrome(executable_path=driver_path,
-                                  options=options)
+            self._driver = Chrome(executable_path=self._driver_path,
+                                  options=self._options)
         except WebDriverException:
-            sys.exit("Invalid path to Chrome driver: {}".format(driver_path))
+            sys.exit("Invalid path to Chrome driver: {}".format(self._driver_path))
 
         if type(self) == Site:
             raise Exception("Cannont execute using Site baseclass")
 
         self.execute()
+
 
     def clickButton(self, button_xpath):
         try:


### PR DESCRIPTION
Added small CLI interface that reads jobs from a json file and spins up a process for each site/product combination.

Also changed semantics for starting up the browser window to use a `.launch()` method, since you don't necessarily want it to open up upon object instantiation.

Not an optimal solution for doing concurrency, but Python doesn't really do that sort of thing very well anyway.

Closes #5
Closes #4
Closes #3 